### PR TITLE
issue #55 resolved using type conversion

### DIFF
--- a/imagededup/methods/cnn.py
+++ b/imagededup/methods/cnn.py
@@ -236,7 +236,7 @@ class CNN:
             duplicates_bool = (j >= min_similarity_threshold) & (j < 2)
 
             if scores:
-                tmp = np.array([*zip(image_ids, j)], dtype=object)
+                tmp = np.array([*zip(image_ids, list(map(str,j)))], dtype=object)
                 duplicates = list(map(tuple, tmp[duplicates_bool]))
 
             else:


### PR DESCRIPTION
Issue #55:
When I called CNN's find_duplicates() function with scores=True, I am getting Typeerror: Object of type float32 is not JSON serializable.
Now it's fixed by converting the scores list elements to string instead of float. Changes are there in line #239